### PR TITLE
"nanoc"を"Nanoc"に修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Postmanを使って自分のユーザー情報を取得するリクエストを�
         "name": "blog",
         "auto_init": true,
         "private": true,
-        "gitignore_template": "nanoc"
+        "gitignore_template": "Nanoc"
       }' \
     https://api.github.com/user/repos
 HTTP/2 404
@@ -162,7 +162,7 @@ repoにチェックを付ける。
         "name": "blog",
         "auto_init": true,
         "private": true,
-        "gitignore_template": "nanoc"
+        "gitignore_template": "Nanoc"
       }' \
     https://api.github.com/user/repos
 HTTP/2 201
@@ -199,7 +199,7 @@ visibilityの値がprivate、privateの値がtrueになっていること。
         "name": "blog",
         "auto_init": true,
         "private": true,
-        "gitignore_template": "nanoc"
+        "gitignore_template": "Nanoc"
       }' \
     https://api.github.com/user/repos
 HTTP/2 422


### PR DESCRIPTION
ご確認お願いします。

## 概要
`"gitignore_template": "nanoc"`のままリクエストを送ると422エラーとなるため、
`nanoc`→`Nanoc`と修正しました。